### PR TITLE
Add module-level docstrings

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -1,3 +1,15 @@
+"""Async wrapper for Binance Futures REST API.
+
+This client simplifies fetching candle data and account information.
+Typical usage:
+
+```
+cfg = json.load(open('config.json'))
+client = BinanceClient(cfg)
+df = await client.fetch_candles('BTCUSDT', '1h')
+```
+"""
+
 import ccxt.async_support as ccxt
 import pandas as pd
 import logging

--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -1,3 +1,9 @@
+"""Retrain XGBoost model using recent trade logs.
+
+The script fetches historical candles, extracts features and updates
+``model_xgb.pkl``. Run ``python auto_retrain.py`` to generate a new model.
+"""
+
 import pandas as pd
 import numpy as np
 import ccxt

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -1,3 +1,9 @@
+"""Simple backtesting utilities based on recorded trade logs.
+
+Calling ``simulate_trades()`` reads ``trade_log.csv`` and reports metrics
+such as win rate and drawdown.
+"""
+
 import pandas as pd
 import numpy as np
 import os

--- a/exchange_client.py
+++ b/exchange_client.py
@@ -1,3 +1,9 @@
+"""Generic async client for multiple exchanges.
+
+Supports Binance and Phemex with an interface similar to ``BinanceClient``.
+Instantiate with a config dictionary containing credentials.
+"""
+
 import ccxt.async_support as ccxt
 import asyncio
 import logging

--- a/fetch_ohlcv.py
+++ b/fetch_ohlcv.py
@@ -1,3 +1,10 @@
+"""Download OHLCV data from Binance Futures and store CSV files.
+
+Run the script directly to fetch a month of candles for popular symbols:
+
+``python fetch_ohlcv.py``
+"""
+
 import ccxt.async_support as ccxt
 import pandas as pd
 import asyncio

--- a/live_strategy.py
+++ b/live_strategy.py
@@ -1,3 +1,10 @@
+"""Multi-timeframe trading strategy for Binance Futures.
+
+`LiveMAStrategy` loads historical candles, calculates indicators and can
+execute trades or simulate training/backtests. Instantiate with a
+`BinanceClient` and call ``initialize`` followed by ``run``.
+"""
+
 import pandas as pd
 import numpy as np
 import ccxt.async_support as ccxt

--- a/main.py
+++ b/main.py
@@ -1,3 +1,9 @@
+"""Entry point for running the trading bot.
+
+Loads ``config.json`` and starts the strategy in live, train or backtest
+mode depending on configuration.
+"""
+
 import asyncio
 import json
 import logging

--- a/optimize_indicators.py
+++ b/optimize_indicators.py
@@ -1,3 +1,9 @@
+"""Utility to search for optimal indicator settings.
+
+``IndicatorOptimizer`` runs backtests with different parameter combinations
+and writes the best configuration back to ``config.json``.
+"""
+
 import logging
 import pandas as pd
 from itertools import product

--- a/signal_engine.py
+++ b/signal_engine.py
@@ -1,3 +1,9 @@
+"""Machine learning helper that scores trade setups.
+
+The engine loads ``model_xgb.pkl`` when available and provides
+``get_signal_for_timeframe`` to compute probabilities.
+"""
+
 import joblib
 import os
 import logging

--- a/train_model.py
+++ b/train_model.py
@@ -1,3 +1,9 @@
+"""Train an XGBoost model from historical trade data.
+
+Execute ``python train_model.py`` to read ``trade_log.csv`` and output
+``model_xgb.pkl`` with cross-validation statistics.
+"""
+
 import pandas as pd
 import numpy as np
 import xgboost as xgb

--- a/websocket_client.py
+++ b/websocket_client.py
@@ -1,3 +1,10 @@
+"""Real-time market data streaming with REST fallback.
+
+`start_streams` opens Binance WebSocket connections and feeds data to a
+strategy instance. If connections fail, historical candles are fetched via
+the REST API.
+"""
+
 import asyncio
 import json
 import websockets


### PR DESCRIPTION
## Summary
- add concise docstrings to clarify purpose and usage of each Python module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840218fe4388323a9390f71521d5dd6