### PR TITLE
Add AI entry filter and liquidity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Modes available via the `mode` key in `config.json`:
 * `train` - update the model using logged trades
 * `backtest` - replay trades to evaluate performance
 
+### New options
+
+* `min_ai_confidence` - probability threshold (0-1) required by the AI model to allow an entry
+* Spread and depth are automatically checked before orders to avoid poor fills
+
 ## Sample data
 
 Example trade logs are stored in the `data/` directory. The scripts

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "testnet": true,
     "leverage": 10,
     "entry_timeout_sec": 30,
+    "min_ai_confidence": 0.5,
     "max_trades_per_day": 5,
     "signal_priority": false,
     "tp": {"BTCUSDT": 0.07},


### PR DESCRIPTION
## Summary
- apply machine learning probability check before opening a trade
- verify order book spread and depth before submitting orders
- document new config option and auto checks

## Testing
- `pytest`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68406ddef6948323b7c468ff1159bdc0