### PR TITLE
Handle empty trade logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Modes available via the `mode` key in `config.json`:
 
 Example trade logs are stored in the `data/` directory. The scripts
 expect `data/trade_log.csv` to exist and will append new entries to it.
+Backtests require data in this file; if it's empty the results will also be empty.

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -7,8 +7,28 @@ import numpy as np
 
 def simulate_trades(trade_log_path='data/trade_log.csv', initial_balance=1000):
     df = pd.read_csv(trade_log_path)
+    if df.empty:
+        metrics = {
+            'Total Trades': 0,
+            'Win Rate': 0,
+            'Final Balance': round(initial_balance, 2),
+            'Max Drawdown': 0,
+            'Sharpe Ratio': 0,
+        }
+        return metrics, []
+
     df = df[df['type'] == 'ENTRY']
     df = df.sort_values('timestamp')
+
+    if df.empty:
+        metrics = {
+            'Total Trades': 0,
+            'Win Rate': 0,
+            'Final Balance': round(initial_balance, 2),
+            'Max Drawdown': 0,
+            'Sharpe Ratio': 0,
+        }
+        return metrics, []
 
     balance = initial_balance
     equity_curve = []


### PR DESCRIPTION
## Summary
- gracefully exit backtests if the trade log is empty
- document that backtests need data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68409fa0da1c832399f204b1b7b1c9bf