### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,18 @@ lead to import errors.
 pip install -r requirements.txt
 ```
 
+Additional dependencies used by optional features include `xgboost`,
+`scikit-learn`, `joblib` and `websockets`.
+
 ## Usage
 
-Edit `config.json` with your API credentials then run:
+Edit `config.json` with your API credentials then run. Alternatively set the
+`BINANCE_API_KEY` and `BINANCE_API_SECRET` environment variables to avoid
+storing keys in the file:
 
 ```bash
+export BINANCE_API_KEY=your_key
+export BINANCE_API_SECRET=your_secret
 python main.py
 ```
 
@@ -37,3 +44,9 @@ Modes available via the `mode` key in `config.json`:
 Example trade logs are stored in the `data/` directory. The scripts
 expect `data/trade_log.csv` to exist and will append new entries to it.
 Backtests require data in this file; if it's empty the results will also be empty.
+
+## Disclaimer
+
+This project is provided for educational purposes only. Trading
+cryptocurrencies involves significant risk and may result in financial loss.
+Use the code at your own discretion.

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 from api_client import BinanceClient
 from live_strategy import LiveMAStrategy
 from backtest_engine import simulate_trades
@@ -25,6 +26,8 @@ async def main():
         logger.info("Starting bot...")
         with open('config.json', 'r') as f:
             cfg = json.load(f)
+        cfg['api_key'] = os.environ.get('BINANCE_API_KEY', cfg.get('api_key'))
+        cfg['api_secret'] = os.environ.get('BINANCE_API_SECRET', cfg.get('api_secret'))
         logger.debug(f"Config loaded: {cfg}")
         client = BinanceClient(cfg)
         strategy = LiveMAStrategy(client, cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ pandas==2.2.2
 ta-lib==0.6.3
 numpy==1.26.4
 rich==13.7.1
+xgboost
+scikit-learn
+joblib
+websockets


### PR DESCRIPTION
## Summary
- document environment variable usage for API keys
- add trading risk disclaimer
- note optional dependencies and update requirements
- support API keys from env vars in `main.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68412169cf508323adacf47c437b0850