### PR TITLE
Fix trade log header handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ Modes available via the `mode` key in `config.json`:
 
 Example trade logs are stored in the `data/` directory. The scripts
 expect `data/trade_log.csv` to exist and will append new entries to it.
+The log file now begins with the header `timestamp,symbol,timeframe,type,entry_price,exit_price,pnl_pct,result`.
 Backtests require data in this file; if it's empty the results will also be empty.

--- a/data/trade_log.csv
+++ b/data/trade_log.csv
@@ -1,3 +1,4 @@
+timestamp,symbol,timeframe,type,entry_price,exit_price,pnl_pct,result
 2025-05-31 02:55:55,BTCUSDT,1h,ENTRY,103559.2,0,0,open
 2025-05-31 02:58:39,BTCUSDT,1h,ENTRY,103550.02,0,0,open
 2025-05-31 02:59:03,SOLUSDT,1h,ENTRY,154.21,0,0,open

--- a/live_strategy.py
+++ b/live_strategy.py
@@ -5,6 +5,7 @@ import ccxt.async_support as ccxt
 import asyncio
 import logging
 import talib
+import os
 from datetime import datetime, timedelta
 import traceback
 from auto_retrain import train_from_log
@@ -332,8 +333,14 @@ class LiveMAStrategy:
     def log_trade(self,symbol,trade_type,entry,exit_price,result,timeframe):
         row=[datetime.now().strftime('%Y-%m-%d %H:%M:%S'),symbol,timeframe,trade_type,entry,exit_price,((exit_price-entry)/entry*100 if trade_type=='EXIT' else 0),result]
         try:
-            with open('data/trade_log.csv','a') as f: f.write(','.join(map(str,row))+'\n')
-        except: pass
+            log_path='data/trade_log.csv'
+            needs_header=not os.path.exists(log_path) or os.path.getsize(log_path)==0
+            with open(log_path,'a') as f:
+                if needs_header:
+                    f.write('timestamp,symbol,timeframe,type,entry_price,exit_price,pnl_pct,result\n')
+                f.write(','.join(map(str,row))+'\n')
+        except Exception:
+            pass
 
     def get_recent_trades(self,symbol=None):
         try:


### PR DESCRIPTION
## Summary
- add CSV header to sample trade log
- document the new header in README
- ensure `log_trade` writes the header when creating a new log file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q pandas numpy`
- `python backtest_engine.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6841215e75d0832393a9d7a5e3b69b23