### PR TITLE
Update maker order handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Modes available via the `mode` key in `config.json`:
 ### New options
 
 * `min_ai_confidence` - probability threshold (0-1) required by the AI model to allow an entry
+* `maker_offset` - fraction added/subtracted from best bid/ask when submitting post-only orders (default `0`)
 * Spread and depth are automatically checked before orders to avoid poor fills
 * The AI model expects the following features: `ema_short`, `ema_long`, `macd`,
   `macdsignal`, `rsi`, `adx`, `obv`, `atr`, `volume`

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "entry_timeout_sec": 30,
     "min_ai_confidence": 0.5,
     "max_trades_per_day": 5,
+    "maker_offset": 0.0001,
     "signal_priority": false,
     "tp": {"BTCUSDT": 0.07},
     "sl": {"BTCUSDT": 0.025},


### PR DESCRIPTION
## Summary
- cancel failed post-only orders instead of using market orders
- add optional `maker_offset` config to tweak limit order price
- document new option in README

## Testing
- `pip install pandas`
- `pip install websockets`
- `pip install ccxt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841421391c483238e250dfbd136d054