### PR TITLE
Add test setup script to CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,6 +39,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install test requirements
+      run: bash scripts/setup_test_env.sh
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+python -m pip install --upgrade pip
+pip install pandas websockets ccxt pytest-asyncio


### PR DESCRIPTION
## Summary
- add `setup_test_env.sh` for CI test environment
- install test requirements in workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414ae54ddc8323a4f5c8840cac807b