### PR TITLE
Configure periods from config

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -9,6 +9,7 @@ import talib
 import time
 import os
 import logging
+import json
 from sklearn.utils.class_weight import compute_class_weight
 from features import extract_features
 
@@ -34,6 +35,9 @@ def train_from_log(trade_log='data/trade_log.csv'):
         logger.error(f"Arquivo {trade_log} não encontrado.")
         return
 
+    with open('config.json', 'r') as f:
+        cfg = json.load(f)
+
     trades = pd.read_csv(trade_log)
     trades = trades.dropna()
     trades = trades[trades['type'] == 'ENTRY']
@@ -56,7 +60,7 @@ def train_from_log(trade_log='data/trade_log.csv'):
             logger.warning(f"Dados vazios para {symbol} {timeframe}, pulando...")
             continue
 
-        feats = extract_features(df)
+        feats = extract_features(df, symbol, cfg)
         if feats.empty:
             logger.warning(f"Features vazias para {symbol} {timeframe}, pulando...")
             continue

--- a/features.py
+++ b/features.py
@@ -2,17 +2,25 @@ import pandas as pd
 import talib
 
 
-def extract_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Compute model features from OHLCV dataframe."""
+def extract_features(df: pd.DataFrame, symbol: str, config: dict) -> pd.DataFrame:
+    """Compute model features from OHLCV dataframe using config periods."""
+    ind_cfg = config.get('indicators', {}).get(symbol, {})
+    ema_short_p = ind_cfg.get('ema_short', 9)
+    ema_long_p = ind_cfg.get('ema_long', 21)
+    rsi_p = ind_cfg.get('rsi', 14)
+    macd_fast = ind_cfg.get('macd_fast', 12)
+    macd_slow = ind_cfg.get('macd_slow', 26)
+    macd_signal = ind_cfg.get('macd_signal', 9)
+
     features = pd.DataFrame()
-    features['ema_short'] = talib.EMA(df['close'], timeperiod=9)
-    features['ema_long'] = talib.EMA(df['close'], timeperiod=21)
+    features['ema_short'] = talib.EMA(df['close'], timeperiod=ema_short_p)
+    features['ema_long'] = talib.EMA(df['close'], timeperiod=ema_long_p)
     macd, macdsignal, _ = talib.MACD(
-        df['close'], fastperiod=12, slowperiod=26, signalperiod=9
+        df['close'], fastperiod=macd_fast, slowperiod=macd_slow, signalperiod=macd_signal
     )
     features['macd'] = macd
     features['macdsignal'] = macdsignal
-    features['rsi'] = talib.RSI(df['close'], timeperiod=14)
+    features['rsi'] = talib.RSI(df['close'], timeperiod=rsi_p)
     features['adx'] = talib.ADX(df['high'], df['low'], df['close'], timeperiod=14)
     features['obv'] = talib.OBV(df['close'], df['volume'])
     features['atr'] = talib.ATR(df['high'], df['low'], df['close'], timeperiod=14)

--- a/live_strategy.py
+++ b/live_strategy.py
@@ -114,7 +114,11 @@ class LiveMAStrategy:
         long=short=0
         if ema_s.iloc[-1]>ema_l.iloc[-1]: long+=2
         elif ema_s.iloc[-1]<ema_l.iloc[-1]: short+=2
-        macd,signal,_=talib.MACD(df['close'],12,26,9)
+        ind_cfg=self.config['indicators'][symbol]
+        macd_fast=ind_cfg.get('macd_fast',12)
+        macd_slow=ind_cfg.get('macd_slow',26)
+        macd_sig=ind_cfg.get('macd_signal',9)
+        macd,signal,_=talib.MACD(df['close'],macd_fast,macd_slow,macd_sig)
         if macd.iloc[-1]>signal.iloc[-1]: long+=1
         elif macd.iloc[-1]<signal.iloc[-1]: short+=1
         rsi=talib.RSI(df['close'],timeperiod=self.config['indicators'][symbol].get('rsi',14))
@@ -150,7 +154,11 @@ class LiveMAStrategy:
         ema_l=talib.EMA(df['close'],timeperiod=self.config['indicators'][symbol].get('ema_long',26))
         if ema_s.iloc[-1]>ema_l.iloc[-1]: long+=2
         elif ema_s.iloc[-1]<ema_l.iloc[-1]: short+=2
-        macd,signal,_=talib.MACD(df['close'],12,26,9)
+        ind_cfg=self.config['indicators'][symbol]
+        macd_fast=ind_cfg.get('macd_fast',12)
+        macd_slow=ind_cfg.get('macd_slow',26)
+        macd_sig=ind_cfg.get('macd_signal',9)
+        macd,signal,_=talib.MACD(df['close'],macd_fast,macd_slow,macd_sig)
         if macd.iloc[-1]>signal.iloc[-1]: long+=1
         elif macd.iloc[-1]<signal.iloc[-1]: short+=1
         rsi=talib.RSI(df['close'],timeperiod=self.config['indicators'][symbol].get('rsi',14))
@@ -212,10 +220,16 @@ class LiveMAStrategy:
             df = self.data[symbol].get(timeframe, pd.DataFrame())
             if df.empty or len(df) < 30:
                 return True
-            ema = talib.EMA(df['close'], timeperiod=12).iloc[-1]
-            macd, _, _ = talib.MACD(df['close'], 12, 26, 9)
+            ind_cfg = self.config['indicators'].get(symbol, {})
+            ema_period = ind_cfg.get('ema_short', 12)
+            ema = talib.EMA(df['close'], timeperiod=ema_period).iloc[-1]
+            macd_fast = ind_cfg.get('macd_fast', 12)
+            macd_slow = ind_cfg.get('macd_slow', 26)
+            macd_sig = ind_cfg.get('macd_signal', 9)
+            macd, _, _ = talib.MACD(df['close'], macd_fast, macd_slow, macd_sig)
             macd_val = macd.iloc[-1]
-            rsi = talib.RSI(df['close'], 14).iloc[-1]
+            rsi_period = ind_cfg.get('rsi', 14)
+            rsi = talib.RSI(df['close'], rsi_period).iloc[-1]
             adx = talib.ADX(df['high'], df['low'], df['close'], 14).iloc[-1]
             obv = talib.OBV(df['close'], df['volume']).iloc[-1]
             atr = talib.ATR(df['high'], df['low'], df['close'], 14).iloc[-1]

--- a/train_model.py
+++ b/train_model.py
@@ -6,6 +6,7 @@ import xgboost as xgb
 import talib
 import joblib
 import logging
+import json
 from sklearn.model_selection import StratifiedKFold, cross_val_score
 from features import extract_features
 
@@ -16,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl'):
     try:
+        with open('config.json', 'r') as f:
+            cfg = json.load(f)
+
         trades = pd.read_csv(log_path)
         trades = trades.dropna()
         trades = trades[trades['type'] == 'ENTRY']
@@ -33,7 +37,7 @@ def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl'):
                     'volume': [row['volume']]
                 })
                 df = pd.concat([df] * 150, ignore_index=True)  # Simular série temporal
-                feats = extract_features(df)
+                feats = extract_features(df, row['symbol'], cfg)
                 if feats.empty:
                     continue
                 X_list.append(feats.iloc[-1])


### PR DESCRIPTION
## Summary
- add config-based period selection in `extract_features`
- load config in train and retrain utilities
- use config values for MACD and other indicators in strategy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414a61d0c483238b3a7af3ffb28cbf