### PR TITLE
Make EMA periods configurable

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -42,6 +42,7 @@ def train_from_log(trade_log='data/trade_log.csv', config_file='config.json'):
     bb_k = cfg.get('bb_k', 2)
     stoch_k_period = cfg.get('stoch_k_period', 14)
     stoch_d_period = cfg.get('stoch_d_period', 3)
+    indicator_cfg = cfg.get('indicators', {})
     trades = trades.dropna()
     trades = trades[trades['type'] == 'ENTRY']
     logger.info(f"Carregando {len(trades)} trades do log.")
@@ -63,12 +64,16 @@ def train_from_log(trade_log='data/trade_log.csv', config_file='config.json'):
             logger.warning(f"Dados vazios para {symbol} {timeframe}, pulando...")
             continue
 
+        ema_short = indicator_cfg.get(symbol, {}).get('ema_short', 9)
+        ema_long = indicator_cfg.get(symbol, {}).get('ema_long', 21)
         feats = extract_features(
             df,
             bb_period=bb_period,
             bb_k=bb_k,
             stoch_k_period=stoch_k_period,
             stoch_d_period=stoch_d_period,
+            ema_short=ema_short,
+            ema_long=ema_long,
         )
         if feats.empty:
             logger.warning(f"Features vazias para {symbol} {timeframe}, pulando...")

--- a/features.py
+++ b/features.py
@@ -8,11 +8,23 @@ def extract_features(
     bb_k: float = 2,
     stoch_k_period: int = 14,
     stoch_d_period: int = 3,
+    ema_short: int = 9,
+    ema_long: int = 21,
 ) -> pd.DataFrame:
-    """Compute model features from OHLCV dataframe."""
+    """Compute model features from OHLCV dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Candle data with columns ``open``, ``high``, ``low``, ``close`` and ``volume``.
+    ema_short : int, optional
+        Period for the short exponential moving average.
+    ema_long : int, optional
+        Period for the long exponential moving average.
+    """
     features = pd.DataFrame()
-    features['ema_short'] = talib.EMA(df['close'], timeperiod=9)
-    features['ema_long'] = talib.EMA(df['close'], timeperiod=21)
+    features['ema_short'] = talib.EMA(df['close'], timeperiod=ema_short)
+    features['ema_long'] = talib.EMA(df['close'], timeperiod=ema_long)
     macd, macdsignal, _ = talib.MACD(
         df['close'], fastperiod=12, slowperiod=26, signalperiod=9
     )

--- a/live_strategy.py
+++ b/live_strategy.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import traceback
 from auto_retrain import train_from_log
 from signal_engine import SignalEngine
+from features import extract_features
 
 logger = logging.getLogger(__name__)
 
@@ -213,33 +214,16 @@ class LiveMAStrategy:
             df = self.data[symbol].get(timeframe, pd.DataFrame())
             if df.empty or len(df) < 30:
                 return True
-            ema_short = talib.EMA(
-                df['close'],
-                timeperiod=self.config['indicators'][symbol].get('ema_short', 12)
-            ).iloc[-1]
-            ema_long = talib.EMA(
-                df['close'],
-                timeperiod=self.config['indicators'][symbol].get('ema_long', 26)
-            ).iloc[-1]
-            macd, macdsignal, _ = talib.MACD(df['close'], 12, 26, 9)
-            macd_val = macd.iloc[-1]
-            macdsignal_val = macdsignal.iloc[-1]
-            rsi = talib.RSI(df['close'], 14).iloc[-1]
-            adx = talib.ADX(df['high'], df['low'], df['close'], 14).iloc[-1]
-            obv = talib.OBV(df['close'], df['volume']).iloc[-1]
-            atr = talib.ATR(df['high'], df['low'], df['close'], 14).iloc[-1]
-            volume = df['volume'].iloc[-1]
-            features = {
-                'ema_short': ema_short,
-                'ema_long': ema_long,
-                'macd': macd_val,
-                'macdsignal': macdsignal_val,
-                'rsi': rsi,
-                'adx': adx,
-                'obv': obv,
-                'atr': atr,
-                'volume': volume,
-            }
+            feats = extract_features(
+                df,
+                bb_period=self.config.get('bb_period', 20),
+                bb_k=self.config.get('bb_k', 2),
+                stoch_k_period=self.config.get('stoch_k_period', 14),
+                stoch_d_period=self.config.get('stoch_d_period', 3),
+                ema_short=self.config['indicators'][symbol].get('ema_short', 12),
+                ema_long=self.config['indicators'][symbol].get('ema_long', 26),
+            )
+            features = feats.iloc[-1].to_dict()
             result = self.signal_engine.get_signal_for_timeframe(features, symbol=symbol, timeframe=timeframe)
             return result['ok'] and result['confidence'] >= self.min_ai_confidence
         except Exception as e:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import talib
+
+from features import extract_features
+from live_strategy import LiveMAStrategy
+
+class DummyClient:
+    pass
+
+class DummySignalEngine:
+    def __init__(self):
+        self.calls = []
+
+    def get_signal_for_timeframe(self, data, **kwargs):
+        self.calls.append((data, kwargs))
+        return {"ok": True, "confidence": 1.0}
+
+def make_df(n=40):
+    return pd.DataFrame({
+        'open': range(1, n+1),
+        'high': range(1, n+1),
+        'low': range(1, n+1),
+        'close': range(1, n+1),
+        'volume': [1]*n,
+    })
+
+
+def test_extract_features_custom_ema():
+    df = make_df()
+    feats = extract_features(df, ema_short=3, ema_long=5)
+    expected_short = talib.EMA(df['close'], timeperiod=3).iloc[-1]
+    expected_long = talib.EMA(df['close'], timeperiod=5).iloc[-1]
+    assert abs(feats.iloc[-1]['ema_short'] - expected_short) < 1e-8
+    assert abs(feats.iloc[-1]['ema_long'] - expected_long) < 1e-8
+
+
+def test_ai_accepts_trade_passes_config(monkeypatch):
+    config = {
+        'indicators': {'BTCUSDT': {'ema_short': 5, 'ema_long': 10}},
+        'bb_period': 20,
+        'bb_k': 2,
+        'stoch_k_period': 14,
+        'stoch_d_period': 3,
+        'min_ai_confidence': 0,
+    }
+    strat = LiveMAStrategy(DummyClient(), config)
+    strat.signal_engine = DummySignalEngine()
+    df = make_df()
+    strat.data['BTCUSDT'] = {'1m': df}
+
+    captured = {}
+
+    def fake_extract(df, bb_period, bb_k, stoch_k_period, stoch_d_period, ema_short, ema_long):
+        captured['ema_short'] = ema_short
+        captured['ema_long'] = ema_long
+        return extract_features(df.tail(30), bb_period, bb_k, stoch_k_period, stoch_d_period, ema_short, ema_long)
+
+    monkeypatch.setattr('live_strategy.extract_features', fake_extract)
+
+    assert strat.ai_accepts_trade('BTCUSDT', '1m')
+    assert captured['ema_short'] == 5
+    assert captured['ema_long'] == 10

--- a/train_model.py
+++ b/train_model.py
@@ -24,6 +24,7 @@ def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl', con
         bb_k = cfg.get('bb_k', 2)
         stoch_k_period = cfg.get('stoch_k_period', 14)
         stoch_d_period = cfg.get('stoch_d_period', 3)
+        indicator_cfg = cfg.get('indicators', {})
         trades = trades.dropna()
         trades = trades[trades['type'] == 'ENTRY']
 
@@ -40,12 +41,16 @@ def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl', con
                     'volume': [row['volume']]
                 })
                 df = pd.concat([df] * 150, ignore_index=True)  # Simular série temporal
+                ema_short = indicator_cfg.get(row['symbol'], {}).get('ema_short', 9)
+                ema_long = indicator_cfg.get(row['symbol'], {}).get('ema_long', 21)
                 feats = extract_features(
                     df,
                     bb_period=bb_period,
                     bb_k=bb_k,
                     stoch_k_period=stoch_k_period,
                     stoch_d_period=stoch_d_period,
+                    ema_short=ema_short,
+                    ema_long=ema_long,
                 )
                 if feats.empty:
                     continue


### PR DESCRIPTION
## Summary
- add ema_short/ema_long params to `extract_features`
- wire EMA params through training and auto retrain utilities
- ensure live strategy uses config EMA values when generating model features
- test configurable EMA handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684152a1080083239a6062224dd40167