### PR TITLE
Add pytest-asyncio and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ This installs all required libraries including `xgboost`, `joblib`,
 Additional dependencies used by optional features include `xgboost`,
 `scikit-learn`, `joblib` and `websockets`.
 
+## Running tests
+
+Install the packages required for the test suite with:
+
+```bash
+bash scripts/setup_test_env.sh
+```
+
+This script installs tools like `pytest-asyncio` which are needed for
+`pytest` to run `tests/test_websocket_client.py`.
+
 ## Usage
 
 Edit `config.json` with your API credentials then run. Alternatively set the

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ rich==13.7.1
 xgboost==3.0.2
 websockets==15.0.1
 joblib==1.5.1
+pytest-asyncio==1.0.0
 


### PR DESCRIPTION
## Summary
- install `pytest-asyncio` via `requirements.txt`
- document how to install test dependencies in README

## Testing
- `bash scripts/setup_test_env.sh`
- `pytest -k websocket_client -vv`


------
https://chatgpt.com/codex/tasks/task_e_684152a451108323b968ac32e1b7e95a