### PR TITLE
Add MACD keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Modes available via the `mode` key in `config.json`:
 * `signal_priority` - when `true`, bypass AI and liquidity checks so raw signals trigger trades immediately
 * Spread and depth are automatically checked before orders to avoid poor fills
 * The AI model expects the following features: `ema_short`, `ema_long`, `macd`, `macdsignal`, `rsi`, `adx`, `obv`, `atr`, `volume`, `bb_upper`, `bb_middle`, `bb_lower`, `stoch_k`, `stoch_d`, `vwap`
+
+### Indicators
+
+Each symbol has its own indicator configuration inside `config.json`. Example:
+
+```json
+"indicators": {
+    "BTCUSDT": {
+        "ema_short": 12,
+        "ema_long": 26,
+        "rsi": 14,
+        "macd_fast": 12,
+        "macd_slow": 26,
+        "macd_signal": 9
+    }
+}
+```
 ## Indicator optimization
 
 Earlier versions shipped with a standalone script called

--- a/config.json
+++ b/config.json
@@ -15,7 +15,21 @@
     "tp": {"BTCUSDT": 0.07},
     "sl": {"BTCUSDT": 0.025},
     "indicators": {
-        "BTCUSDT": {"ema_short": 12, "ema_long": 26, "rsi": 14},
-        "SOLUSDT": {"ema_short": 12, "ema_long": 26, "rsi": 14}
+        "BTCUSDT": {
+            "ema_short": 12,
+            "ema_long": 26,
+            "rsi": 14,
+            "macd_fast": 12,
+            "macd_slow": 26,
+            "macd_signal": 9
+        },
+        "SOLUSDT": {
+            "ema_short": 12,
+            "ema_long": 26,
+            "rsi": 14,
+            "macd_fast": 12,
+            "macd_slow": 26,
+            "macd_signal": 9
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend sample indicator settings with MACD parameters
- document `macd_fast`, `macd_slow` and `macd_signal` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684153c0432483238c3747348989b585