### PR TITLE
Update API credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ Additional dependencies used by optional features include `xgboost`,
 
 ## Usage
 
-Edit `config.json` with your API credentials then run. Alternatively set the
-`BINANCE_API_KEY` and `BINANCE_API_SECRET` environment variables to avoid
-storing keys in the file:
+Set the `BINANCE_API_KEY` and `BINANCE_API_SECRET` environment variables before running the bot.
 
 ```bash
 export BINANCE_API_KEY=your_key

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-    "api_key": "932becea53220bb9244f779bde17b5c594ba0ab1eb4ceb925ec85ea9a446a6fc",
-    "api_secret": "9a41ddf72bbab3a932a61988e588a9b83cdc2a2672c471db8f9d0c359748e9c0",
+    "api_key": "FAKE_API_KEY",
+    "api_secret": "FAKE_API_SECRET",
     "testnet": true,
     "leverage": 10,
     "entry_timeout_sec": 30,


### PR DESCRIPTION
## Summary
- sanitize api key and secret in `config.json`
- clarify README to configure credentials using environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841529fcb5483238eeadaaa7855a192