### PR TITLE
Add configurable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Modes available via the `mode` key in `config.json`:
 * `stoch_k_period` - K period for the Stochastic Oscillator (default `14`)
 * `stoch_d_period` - D period for the Stochastic Oscillator (default `3`)
 * `signal_priority` - when `true`, bypass AI and liquidity checks so raw signals trigger trades immediately
+* `log_level` - logging verbosity level (default `INFO`)
 * Spread and depth are automatically checked before orders to avoid poor fills
 * The AI model expects the following features: `ema_short`, `ema_long`, `macd`, `macdsignal`, `rsi`, `adx`, `obv`, `atr`, `volume`, `bb_upper`, `bb_middle`, `bb_lower`, `stoch_k`, `stoch_d`, `vwap`
 

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "testnet": true,
     "leverage": 10,
     "entry_timeout_sec": 30,
+    "log_level": "INFO",
     "min_ai_confidence": 0.5,
     "max_trades_per_day": 5,
     "maker_offset": 0.0001,

--- a/main.py
+++ b/main.py
@@ -9,23 +9,23 @@ from live_strategy import LiveMAStrategy
 from backtest_engine import simulate_trades
 from websocket_client import start_streams
 
-# Configurar logging para console e arquivo
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('bot.log'),
-        logging.StreamHandler()
-    ]
-)
-
 async def main():
     ws_task = None
     try:
-        logger = logging.getLogger(__name__)
-        logger.info("Starting bot...")
         with open('config.json', 'r') as f:
             cfg = json.load(f)
+
+        logging.basicConfig(
+            level=getattr(logging, cfg.get("log_level", "INFO").upper()),
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            handlers=[
+                logging.FileHandler('bot.log'),
+                logging.StreamHandler()
+            ]
+        )
+
+        logger = logging.getLogger(__name__)
+        logger.info("Starting bot...")
         cfg['api_key'] = os.environ.get('BINANCE_API_KEY', cfg.get('api_key'))
         cfg['api_secret'] = os.environ.get('BINANCE_API_SECRET', cfg.get('api_secret'))
         logger.debug(f"Config loaded: {cfg}")


### PR DESCRIPTION
## Summary
- allow log verbosity to be configured via `config.json`
- default log level is `INFO`
- document the option in README

## Testing
- `pip install -q -r requirements.txt` *(fails: ta-lib build error)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68416b50403c8323bc5d665c9c6e5295