### PR TITLE
Improve training log handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ displayed in the console.
 
 The log file now begins with the header `timestamp,symbol,timeframe,type,entry_price,exit_price,pnl_pct,result`.
 Backtests require data in this file; if it's empty, the results will also be empty.
+For training, ensure every `ENTRY` row eventually has a matching `EXIT` row with
+the final trade result. Rows without an `EXIT` counterpart will be skipped during
+retraining.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- warn in `train_from_log` if there are only ENTRY rows and no EXIT rows
- skip entries without win/loss results
- document the need for logging both ENTRY and EXIT lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68418c3abed88323a24999d2ae15e287