### PR TITLE
Add exit order tracking

### DIFF
--- a/live_strategy.py
+++ b/live_strategy.py
@@ -238,10 +238,19 @@ class LiveMAStrategy:
                         if not any(o['type'].upper() in ['STOP_MARKET','TAKE_PROFIT_MARKET'] for o in orders):
                             await self.set_sl(symbol); await self.set_tp(symbol)
                     break
-            if not active and self.position_side[symbol] is not None:
+            if not active:
                 await self.check_exit_fills(symbol)
+                for o in orders:
+                    if o['status']=='open' and o['type'].upper() in ['STOP_MARKET','TAKE_PROFIT_MARKET']:
+                        await self.client.exchange.cancel_order(o['id'],symbol)
                 if self.position_side[symbol] is not None:
-                    self.position_side[symbol]=None; self.entry_price[symbol]=None; self.quantity[symbol]=None; self.unrealized_pnl[symbol]=0
+                    self.position_side[symbol]=None
+                    self.entry_price[symbol]=None
+                    self.quantity[symbol]=None
+                    self.unrealized_pnl[symbol]=0
+                self.sl_order_id[symbol]=None
+                self.tp_order_id[symbol]=None
+                self.entry_tf[symbol]=None
             for o in orders:
                 if o['status']=='open' and o['type'].upper() not in ['STOP_MARKET','TAKE_PROFIT_MARKET']:
                     await self.client.exchange.cancel_order(o['id'],symbol)

--- a/tests/test_exit_logging.py
+++ b/tests/test_exit_logging.py
@@ -1,0 +1,59 @@
+import asyncio
+import pytest
+import os, sys, types, types as modtypes
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault('xgboost', types.SimpleNamespace())
+dummy_sk = modtypes.ModuleType('sklearn')
+dummy_utils = modtypes.ModuleType('sklearn.utils')
+dummy_cw = modtypes.ModuleType('sklearn.utils.class_weight')
+dummy_cw.compute_class_weight = lambda *a, **k: None
+dummy_utils.class_weight = dummy_cw
+sys.modules.setdefault('sklearn', dummy_sk)
+sys.modules.setdefault('sklearn.utils', dummy_utils)
+sys.modules.setdefault('sklearn.utils.class_weight', dummy_cw)
+
+from live_strategy import LiveMAStrategy
+
+class DummyExchange:
+    def __init__(self):
+        self.canceled = []
+    async def fetch_order(self, order_id, symbol):
+        if order_id == 'sl123':
+            return {'id': order_id, 'status': 'FILLED', 'avgPrice': '99'}
+        return {'id': order_id, 'status': 'open'}
+    async def fapiPrivateV2GetPositionRisk(self, params):
+        return [{'positionAmt': '0'}]
+    async def fetch_open_orders(self, symbol):
+        return []
+    async def cancel_order(self, order_id, symbol):
+        self.canceled.append(order_id)
+
+class DummyClient:
+    def __init__(self):
+        self.exchange = DummyExchange()
+    async def get_balance(self):
+        return {'USDT': {'free': 1000}}
+
+@pytest.mark.asyncio
+async def test_stop_order_exit(tmp_path, monkeypatch):
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    log_file = data_dir / 'trade_log.csv'
+    log_file.write_text('timestamp,symbol,timeframe,type,entry_price,exit_price,pnl_pct,result\n')
+    monkeypatch.chdir(tmp_path)
+
+    config = {'indicators': {'BTCUSDT': {}}, 'tp': {'BTCUSDT': 0.04}, 'sl': {'BTCUSDT': 0.02}}
+    strat = LiveMAStrategy(DummyClient(), config)
+    strat.position_side['BTCUSDT'] = 'long'
+    strat.entry_price['BTCUSDT'] = 100.0
+    strat.quantity['BTCUSDT'] = 1.0
+    strat.entry_tf['BTCUSDT'] = '1h'
+    strat.sl_order_id['BTCUSDT'] = 'sl123'
+    strat.tp_order_id['BTCUSDT'] = 'tp123'
+
+    await strat.sync_position('BTCUSDT')
+
+    lines = log_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert lines[-1].split(',')[3] == 'EXIT'
+    assert 'tp123' in strat.client.exchange.canceled

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,9 +1,19 @@
-import sys, os
+import sys, os, types, types as modtypes
 import warnings
 import pytest
 pytestmark = pytest.mark.filterwarnings("ignore")
 warnings.filterwarnings("ignore")
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault('xgboost', types.SimpleNamespace())
+dummy_sk = modtypes.ModuleType('sklearn')
+dummy_utils = modtypes.ModuleType('sklearn.utils')
+dummy_cw = modtypes.ModuleType('sklearn.utils.class_weight')
+dummy_cw.compute_class_weight = lambda *a, **k: None
+dummy_utils.class_weight = dummy_cw
+sys.modules.setdefault('sklearn', dummy_sk)
+sys.modules.setdefault('sklearn.utils', dummy_utils)
+sys.modules.setdefault('sklearn.utils.class_weight', dummy_cw)
+
 import pandas as pd
 import talib
 

--- a/tests/test_sync_position.py
+++ b/tests/test_sync_position.py
@@ -1,0 +1,50 @@
+import sys, os
+import pytest
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from live_strategy import LiveMAStrategy
+
+class DummyExchange:
+    def __init__(self):
+        self.orders = [
+            {'id': '1', 'type': 'STOP_MARKET', 'status': 'open'},
+            {'id': '2', 'type': 'TAKE_PROFIT_MARKET', 'status': 'closed'},
+        ]
+        self.cancelled = []
+
+    async def fapiPrivateV2GetPositionRisk(self, params):
+        return [{'positionAmt': '0', 'entryPrice': '0', 'unRealizedProfit': '0'}]
+
+    async def fetch_open_orders(self, symbol):
+        return list(self.orders)
+
+    async def cancel_order(self, order_id, symbol):
+        self.cancelled.append(order_id)
+        for o in self.orders:
+            if o['id'] == order_id:
+                o['status'] = 'canceled'
+
+class DummyClient:
+    def __init__(self, exchange):
+        self.exchange = exchange
+
+@pytest.mark.asyncio
+async def test_sync_position_cancels_sl_tp_when_position_closed():
+    exch = DummyExchange()
+    client = DummyClient(exch)
+    strat = LiveMAStrategy(client, {'indicators': {'BTCUSDT': {}}})
+    strat.position_side['BTCUSDT'] = 'long'
+    strat.entry_price['BTCUSDT'] = 100
+    strat.quantity['BTCUSDT'] = 1
+    strat.unrealized_pnl['BTCUSDT'] = 10
+
+    await strat.sync_position('BTCUSDT')
+
+    assert '1' in exch.cancelled, 'stop order not canceled'
+    assert not any(o['status'] == 'open' for o in exch.orders)
+    assert strat.position_side['BTCUSDT'] is None
+    assert strat.entry_price['BTCUSDT'] is None
+    assert strat.quantity['BTCUSDT'] is None
+    assert strat.unrealized_pnl['BTCUSDT'] == 0


### PR DESCRIPTION
## Summary
- handle stop/limit exit fills in `LiveMAStrategy`
- store IDs for TP/SL orders and track them for exit
- cancel remaining exit order when one fills
- log exit info with actual price
- test exit logging path using a mocked stop fill
- mock heavy ML imports in tests

## Testing
- `bash scripts/setup_test_env.sh`
- `pip install joblib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418c470bb483239596929f0bc7f1ad