### PR TITLE
Add closePosition to SL/TP orders

### DIFF
--- a/live_strategy.py
+++ b/live_strategy.py
@@ -304,7 +304,7 @@ class LiveMAStrategy:
             _,sl=self.calculate_tp_sl(symbol)
             if abs(sl-self.entry_price[symbol])/self.entry_price[symbol]>0.05:
                 sl=round(self.entry_price[symbol]*(0.95 if self.position_side[symbol]=='long' else 1.05),self.price_precision[symbol])
-            params={'stopPrice':sl,'reduceOnly':True,'timeInForce':'GTC'}
+            params={'stopPrice':sl,'reduceOnly':True,'timeInForce':'GTC','closePosition':True}
             try:
                 o=await self.client.exchange.create_order(symbol,'STOP_MARKET','sell' if self.position_side[symbol]=='long' else 'buy',round(self.quantity[symbol],self.quantity_precision[symbol]),None,params)
                 return
@@ -318,7 +318,7 @@ class LiveMAStrategy:
             tp,_=self.calculate_tp_sl(symbol)
             if abs(tp-self.entry_price[symbol])/self.entry_price[symbol]>0.05:
                 tp=round(self.entry_price[symbol]*(1.05 if self.position_side[symbol]=='long' else 0.95),self.price_precision[symbol])
-            params={'stopPrice':tp,'reduceOnly':True,'timeInForce':'GTC'}
+            params={'stopPrice':tp,'reduceOnly':True,'timeInForce':'GTC','closePosition':True}
             try:
                 await self.client.exchange.create_order(symbol,'TAKE_PROFIT_MARKET','sell' if self.position_side[symbol]=='long' else 'buy',round(self.quantity[symbol],self.quantity_precision[symbol]),None,params)
                 return

--- a/tests/test_live_strategy.py
+++ b/tests/test_live_strategy.py
@@ -1,0 +1,58 @@
+import sys, os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from live_strategy import LiveMAStrategy
+
+class DummyExchange:
+    def __init__(self):
+        self.last_params = None
+        self.last_type = None
+
+    async def create_order(self, symbol, order_type, side, amount, price=None, params=None):
+        self.last_params = params
+        self.last_type = order_type
+        return {}
+
+class DummyClient:
+    def __init__(self):
+        self.exchange = DummyExchange()
+
+@pytest.mark.asyncio
+async def test_set_sl_adds_close_position():
+    config = {
+        'indicators': {'BTCUSDT': {}},
+        'tp': {'BTCUSDT': 0.07},
+        'sl': {'BTCUSDT': 0.025},
+        'leverage': 10,
+    }
+    strat = LiveMAStrategy(DummyClient(), config)
+    strat.entry_price['BTCUSDT'] = 100
+    strat.quantity['BTCUSDT'] = 1
+    strat.position_side['BTCUSDT'] = 'long'
+
+    await strat.set_sl('BTCUSDT')
+
+    params = strat.client.exchange.last_params
+    assert params['closePosition'] is True
+    assert strat.client.exchange.last_type == 'STOP_MARKET'
+
+@pytest.mark.asyncio
+async def test_set_tp_adds_close_position():
+    config = {
+        'indicators': {'BTCUSDT': {}},
+        'tp': {'BTCUSDT': 0.07},
+        'sl': {'BTCUSDT': 0.025},
+        'leverage': 10,
+    }
+    strat = LiveMAStrategy(DummyClient(), config)
+    strat.entry_price['BTCUSDT'] = 100
+    strat.quantity['BTCUSDT'] = 1
+    strat.position_side['BTCUSDT'] = 'long'
+
+    await strat.set_tp('BTCUSDT')
+
+    params = strat.client.exchange.last_params
+    assert params['closePosition'] is True
+    assert strat.client.exchange.last_type == 'TAKE_PROFIT_MARKET'


### PR DESCRIPTION
## Summary
- include `closePosition` in SL/TP order parameters
- test that SL/TP orders contain `closePosition`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418c2c5ccc8323a81b6caf7499222c