### PR TITLE
Improve AI trade checks and features

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -78,8 +78,12 @@ def train_from_log(trade_log='data/trade_log.csv', config_file='config.json'):
             logger.warning(f"Dados vazios para {symbol} {timeframe}, pulando...")
             continue
 
-        ema_short = indicator_cfg.get(symbol, {}).get('ema_short', 9)
-        ema_long = indicator_cfg.get(symbol, {}).get('ema_long', 21)
+        cfg = indicator_cfg.get(symbol, {})
+        ema_short = cfg.get('ema_short', 9)
+        ema_long = cfg.get('ema_long', 21)
+        macd_fast = cfg.get('macd_fast', 12)
+        macd_slow = cfg.get('macd_slow', 26)
+        macd_signal = cfg.get('macd_signal', 9)
         feats = extract_features(
             df,
             bb_period=bb_period,
@@ -88,6 +92,9 @@ def train_from_log(trade_log='data/trade_log.csv', config_file='config.json'):
             stoch_d_period=stoch_d_period,
             ema_short=ema_short,
             ema_long=ema_long,
+            macd_fast=macd_fast,
+            macd_slow=macd_slow,
+            macd_signal=macd_signal,
         )
         if feats.empty:
             logger.warning(f"Features vazias para {symbol} {timeframe}, pulando...")

--- a/features.py
+++ b/features.py
@@ -10,6 +10,9 @@ def extract_features(
     stoch_d_period: int = 3,
     ema_short: int = 9,
     ema_long: int = 21,
+    macd_fast: int = 12,
+    macd_slow: int = 26,
+    macd_signal: int = 9,
 ) -> pd.DataFrame:
     """Compute model features from OHLCV dataframe.
 
@@ -22,12 +25,21 @@ def extract_features(
         Period for the short exponential moving average.
     ema_long : int, optional
         Period for the long exponential moving average.
+    macd_fast : int, optional
+        Fast period for the MACD indicator.
+    macd_slow : int, optional
+        Slow period for the MACD indicator.
+    macd_signal : int, optional
+        Signal period for the MACD indicator.
     """
     features = pd.DataFrame()
     features['ema_short'] = talib.EMA(df['close'], timeperiod=ema_short)
     features['ema_long'] = talib.EMA(df['close'], timeperiod=ema_long)
     macd, macdsignal, _ = talib.MACD(
-        df['close'], fastperiod=12, slowperiod=26, signalperiod=9
+        df['close'],
+        fastperiod=macd_fast,
+        slowperiod=macd_slow,
+        signalperiod=macd_signal,
     )
     features['macd'] = macd
     features['macdsignal'] = macdsignal

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -55,7 +55,7 @@ def test_extract_features_custom_ema():
 
 def test_ai_accepts_trade_passes_config(monkeypatch):
     config = {
-        'indicators': {'BTCUSDT': {'ema_short': 5, 'ema_long': 10}},
+        'indicators': {'BTCUSDT': {'ema_short': 5, 'ema_long': 10, 'macd_fast': 8, 'macd_slow': 17, 'macd_signal': 5}},
         'bb_period': 20,
         'bb_k': 2,
         'stoch_k_period': 14,
@@ -77,9 +77,15 @@ def test_ai_accepts_trade_passes_config(monkeypatch):
         stoch_d_period,
         ema_short,
         ema_long,
+        macd_fast,
+        macd_slow,
+        macd_signal,
     ):
         captured['ema_short'] = ema_short
         captured['ema_long'] = ema_long
+        captured['macd_fast'] = macd_fast
+        captured['macd_slow'] = macd_slow
+        captured['macd_signal'] = macd_signal
         return extract_features(
             df.tail(30),
             bb_period,
@@ -88,10 +94,16 @@ def test_ai_accepts_trade_passes_config(monkeypatch):
             stoch_d_period,
             ema_short,
             ema_long,
+            macd_fast,
+            macd_slow,
+            macd_signal,
         )
 
     monkeypatch.setattr('live_strategy.extract_features', fake_extract)
 
-    assert strat.ai_accepts_trade('BTCUSDT', '1m')
+    assert strat.ai_accepts_trade('BTCUSDT', '1m', 'long')
     assert captured['ema_short'] == 5
     assert captured['ema_long'] == 10
+    assert captured['macd_fast'] == 8
+    assert captured['macd_slow'] == 17
+    assert captured['macd_signal'] == 5

--- a/train_model.py
+++ b/train_model.py
@@ -41,8 +41,12 @@ def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl', con
                     'volume': [row['volume']]
                 })
                 df = pd.concat([df] * 150, ignore_index=True)  # Simular série temporal
-                ema_short = indicator_cfg.get(row['symbol'], {}).get('ema_short', 9)
-                ema_long = indicator_cfg.get(row['symbol'], {}).get('ema_long', 21)
+                ind_cfg = indicator_cfg.get(row['symbol'], {})
+                ema_short = ind_cfg.get('ema_short', 9)
+                ema_long = ind_cfg.get('ema_long', 21)
+                macd_fast = ind_cfg.get('macd_fast', 12)
+                macd_slow = ind_cfg.get('macd_slow', 26)
+                macd_signal = ind_cfg.get('macd_signal', 9)
                 feats = extract_features(
                     df,
                     bb_period=bb_period,
@@ -51,6 +55,9 @@ def train_model(log_path='data/trade_log.csv', model_output='model_xgb.pkl', con
                     stoch_d_period=stoch_d_period,
                     ema_short=ema_short,
                     ema_long=ema_long,
+                    macd_fast=macd_fast,
+                    macd_slow=macd_slow,
+                    macd_signal=macd_signal,
                 )
                 if feats.empty:
                     continue


### PR DESCRIPTION
## Summary
- support custom MACD parameters in `extract_features`
- adjust `ai_accepts_trade` to handle short trades and pass MACD config
- fix DataFrame handling in `process_timeframe_data`
- update training utilities for new feature params
- extend feature extraction test for new parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846ec4cbc708323a2b0907f8298c20f