### PR TITLE
Fix ws_timeframes default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Modes available via the `mode` key in `config.json`:
 * `stoch_d_period` - D period for the Stochastic Oscillator (default `3`)
 * `signal_priority` - when `true`, bypass AI and liquidity checks so raw signals trigger trades immediately
 * `log_level` - logging verbosity level (default `INFO`)
+* `ws_timeframes` - list of chart intervals to subscribe to via WebSocket; defaults to the strategy timeframes when unset or `null`
 * Spread and depth are automatically checked before orders to avoid poor fills
 * The AI model expects the following features: `ema_short`, `ema_long`, `macd`, `macdsignal`, `rsi`, `adx`, `obv`, `atr`, `volume`, `bb_upper`, `bb_middle`, `bb_lower`, `stoch_k`, `stoch_d`, `vwap`
 

--- a/websocket_client.py
+++ b/websocket_client.py
@@ -25,9 +25,13 @@ async def start_streams(symbols, timeframes, strategy, valid_timeframes, config)
         "wss://stream.binancefuture.com/stream",
         "wss://fstream.binance.com/stream"
     ]
+    ws_tfs = config.get('ws_timeframes') or timeframes
+    if isinstance(ws_tfs, str):
+        ws_tfs = [ws_tfs]
+
     streams = [
         f"{symbol.lower()}@kline_{tf}" for symbol in symbols
-        for tf in (config.get('ws_timeframes', timeframes))
+        for tf in ws_tfs
     ] + [
         f"{symbol.lower()}@ticker" for symbol in symbols
     ]


### PR DESCRIPTION
## Summary
- handle `None` for `ws_timeframes` when starting websockets
- document `ws_timeframes` option in README

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e8ad30cc8323ab57d67bc9fff6d7