### PR TITLE
Fix redundant exit sync check

### DIFF
--- a/live_strategy.py
+++ b/live_strategy.py
@@ -270,7 +270,7 @@ class LiveMAStrategy:
 
             if not active:
                 # 3) Se não há posição, verifica se uma SL/TP foi preenchida
-                await self.check_exit_fills(symbol)
+                #    (já realizado no passo 1, mantido para compatibilidade)
 
                 # 4) Cancela ordens de SL/TP que ainda estejam abertas
                 for o in orders:


### PR DESCRIPTION
## Summary
- remove duplicate call to `check_exit_fills` in `sync_position`

## Testing
- `bash scripts/setup_test_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472d50a7f483238aea97525d8e0561